### PR TITLE
pgconvert: option to specify output file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ check:	pgcollect pgconvert pginfo pginfo_dbg
 	@echo ""; echo "checking its infos ..."
 	./pginfo callgraph check.pgdata
 	@echo ""; echo "converting both collections to callgrind format ..."
-	./pgconvert check_ls.pgdata -d object       1> check_ls.grind
-	./pgconvert check.pgdata    -d source -i    1> check.grind
+	./pgconvert check_ls.pgdata -d object       1> check_ls.grind  # old: stdout
+	./pgconvert check.pgdata    -d source -i       check.grind     # new: second option
 	@echo ""; echo "done, you may want to issue \"make open-checkfiles\" to open the result via kcachegrind"
 
 open-checkfiles:	check_ls.grind check.grind

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ Options to specify target:
 - `cmd` command to profile, prefix with `--` to stop command line parsing
 
 ## `pgconvert` - convert collected samples to callgrind format
-Usage: `pgconvert [-m {flat|callgraph}] [-d {object|symbol|source}] [-i] filename.pgdata`  
+Usage: `pgconvert [-m {flat|callgraph}] [-d {object|symbol|source}] [-i] filename.pgdata [filename.grind]`  
+Note: If no output name is specified, then stdout will be used instead.  
 Examples:
 - overview showing call stack  
-  `pgconvert -d symbol filename.pgdata > callgrind.out.overfiew_pgdata`
+  `pgconvert -d symbol filename.pgdata overview.grind`
 - full data with source annotation and instructions  
-  `pgconvert -i filename.pgdata > callgrind.out.full_pgdata`
+  `pgconvert -i filename.pgdata full.grind`
 
 Options to adjust generated callgrind data:
 - `-d` specify detail level; default is "source"
@@ -68,7 +69,7 @@ Usage: `pginfo {flat|callgraph} filename.pgdata`
 # Building
 
 ## Dependency [elfutils](https://sourceware.org/elfutils/)
-either install from source or - preferably - via package manager, for example by issuing `sudo yum install elfutils-devel` or `sudo apt install libelf-dev`
+either install from source or - preferably - via package manager, for example by issuing `yum install elfutils-devel` or `apt install libdw-dev`
 
 ## Building the source
 - optional step: create site.mak file and set FLAGS variable with paths to elfutils header and libraries (necessary if using a "local" version of elfutils)  


### PR DESCRIPTION
fixes #11

first take (note: as my experience in c++ is limited, the code is likely not optimal - but it does work for:

* specifying the "special filename '-' -> (stdout)"
* specifying no filename ->(stdout)"
* specifying files that either don't exist and the user can write to the folder or files that are writable